### PR TITLE
fix: preserve order of row fields

### DIFF
--- a/src/components/Row.js
+++ b/src/components/Row.js
@@ -37,16 +37,22 @@ const getRenderer = field => {
   return <div />;
 };
 
-const Row = ({ rowData, fieldsToDisplay }) => (
-  <div className="row">
-    {_.chain(rowData.fields)
-      .map(field =>
-        fieldsToDisplay.includes(field.name) ? getRenderer(field) : null
-      )
-      .filter(renderer => !!renderer)
-      .value()}
-  </div>
-);
+const Row = ({ rowData, fieldsToDisplay }) => {
+  const mapFields = name => {
+    const field = rowData.fields.find(field => field.name === name);
+    if (field) return getRenderer(field);
+
+    return field;
+  };
+  return (
+    <div className="row">
+      {_.chain(fieldsToDisplay)
+        .map(mapFields)
+        .filter(renderer => !!renderer)
+        .value()}
+    </div>
+  );
+};
 
 Row.defaultProps = {
   rowData: {},


### PR DESCRIPTION
instead of using `rowData.fields` as the array to be mapped, we could use the `fieldsToDisplay` instead. Sometimes the field (or column) order that Airtable gives us may not have the same order as what is set in the `.env`'s `HOMEPAGE_FIELD_ORDER` or `FIELD_ORDER` variables. Undeclared fields will still get ignored.

